### PR TITLE
Flann: replace static member for policy with a global variable.

### DIFF
--- a/modules/flann/include/opencv2/flann/any.h
+++ b/modules/flann/include/opencv2/flann/any.h
@@ -165,17 +165,14 @@ class SinglePolicy
 
 public:
     static base_any_policy* get_policy();
-
-private:
-    static typename choose_policy<T>::type policy;
 };
 
 template <typename T>
-typename choose_policy<T>::type SinglePolicy<T>::policy;
+typename choose_policy<T>::type policy;
 
 /// This function will return a different policy for each type.
 template <typename T>
-inline base_any_policy* SinglePolicy<T>::get_policy() { return &policy; }
+inline base_any_policy* SinglePolicy<T>::get_policy() { return &policy<T>; }
 
 } // namespace anyimpl
 


### PR DESCRIPTION
The template class SinglePolicy has a static member variable called
policy. To guarantee a one-time initialization of this static variable
the compiler creates a guard variable. This guard variable is compiled
with different visibility attributes in different compilation units.
This causes multiple linker "different visibility settings" warnings
when linking opencv-based applications.

To eliminate these warnings I have replaced the static member with a
global variable. Global variables are not accompanied with guard
variables, so the issue is resolved. Note: the policy variable is
template; fortunately C++ 14 introduces variable templates.
